### PR TITLE
Controlnet support fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.trt

--- a/models/sd_unet.py
+++ b/models/sd_unet.py
@@ -192,6 +192,10 @@ class SD21UnclipL_TRT(UNetTRT):
             **kwargs,
         )
 
+    @classmethod
+    def from_model(cls, model, **kwargs):
+        return super(SD21UnclipL_TRT, cls).from_model(model, use_control=True)
+
 
 class SD21UnclipH_TRT(UNetTRT):
     def __init__(
@@ -213,6 +217,10 @@ class SD21UnclipH_TRT(UNetTRT):
             num_res_blocks,
             **kwargs,
         )
+
+    @classmethod
+    def from_model(cls, model, **kwargs):
+        return super(SD21UnclipH_TRT, cls).from_model(model, use_control=True)
 
 
 class SDXLRefiner_TRT(UNetTRT):

--- a/tensorrt_nodes.py
+++ b/tensorrt_nodes.py
@@ -336,7 +336,7 @@ class DynamicTRTBuild(TRTBuildBase):
             context_opt,
             context_max,
             num_video_frames,
-            onnx_model_path,
+            onnx_model_path = None,
     ):
         return super()._convert(
             model,
@@ -429,7 +429,7 @@ class StaticTRTBuild(TRTBuildBase):
             width_opt,
             context_opt,
             num_video_frames,
-            onnx_model_path,
+            onnx_model_path = None,
     ):
         return super()._convert(
             model,

--- a/tensorrt_nodes.py
+++ b/tensorrt_nodes.py
@@ -155,9 +155,7 @@ class TRTBuildBase:
             full_output_folder, f"{filename}_{counter:05}_.engine"
         )
 
-        batch_multiplier = (
-            2 if model_helper.is_conditional else 1
-        )  # TODO lets see if we really want this
+        batch_multiplier = 1
         if model_version == "SVD_img2vid":
             batch_multiplier *= num_video_frames
         success = trt_model.build(


### PR DESCRIPTION
Changes in this PR:

- Add a .gitignore to exclude a few files generated during usage.
- I ran into division by 0 errors [here](https://github.com/contentis/ComfyUI_TensorRT/blob/d2fcef4d9063b0c88627e1815ef021fab391515b/tensorrt_diffusion_model.py#L143) and anywhere where there is a division operation with `self.curr_split_batch`. I was using a EmptyLatentImage node with batch_size = 1 connected to a KSampler node that used the TensorRT engine built from your branch as an input. The problem seemed to go away when I set the batch_multiplier to 1 in https://github.com/contentis/ComfyUI_TensorRT/commit/a4dceaedba3945c198e46d67d95b3addc623ea8a. I noticed that during ONNX export the [batch size is also multiplied by 2](https://github.com/contentis/ComfyUI_TensorRT/blob/d2fcef4d9063b0c88627e1815ef021fab391515b/onnx_utils/export.py#L187), but was not sure if that should be left as-is.
- The static/dynamic build nodes were complaining if the onnx_model_path input was not provided which is fixed by setting a default None value in the nodes. It seems that even if the input is marked as optional at the ComfyUI node level, you still need to set a default value for the corresponding param in the function invoked by the node.